### PR TITLE
商品詳細表示サーバーサイドの作成

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -3,6 +3,9 @@ class ProductsController < ApplicationController
   end
 
   def show
+    @image = Image.find_by(id: params[:id])
+    @product = Product.find_by(id: params[:id])
+    @category = @product.category.parent
   end
  
   def new

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -3,8 +3,8 @@ class ProductsController < ApplicationController
   end
 
   def show
-    @image = Image.find_by(id: params[:id])
-    @product = Product.find_by(id: params[:id])
+    @image = Image.find(params[:id])
+    @product = Product.find(params[:id])
     @category = @product.category.parent
   end
  

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -1,16 +1,18 @@
 = render "header"
 .product_show_container
   %section.item-box-container.single-container-section
-    %h1.item-name ドクターマーチン Dr.Martens 1460Z 8 EYE BOOT(8ホールブーツ) 10072004 （ブラック）ドクターマーチン
+    %h1.item-name 
+      = @product.name
     .item-main-content.clearfix
       .item-main-content__photo
-        = image_tag "boots.jpg",class:"item-main-content__photo__image" 
+        = image_tag "#{@image.image}",class:"item-main-content__photo__image" 
       %table.item-main-content__detail-table
         %tbody
           %tr
             %th 出品者
             %td
-              =link_to "ATSU", "#"
+              =link_to "/users/show" do
+                = @product.user.nickname
               .face
                 .item-user-ratings
                   %i.fa.fa-smile 
@@ -25,39 +27,46 @@
             %th カテゴリー
             %td
               =link_to "#" do
-                %div メンズ
+                .name
+                  = @category.root.name
               =link_to "#" do
-                .item-detail-table-sub-category
+                .sub-name
                   %i.fa.fa-chevron-right
-                  靴
+                  = @category.name
               =link_to "#" do
-                .item-detail-table-sub-sub-category
+                .sub-sub-name
                   %i.fa.fa-chevron-right
-                  ブーツ
+                  = @product.category.name
           %tr
             %th ブランド
-            %td ドクターマーチン
+            %td
+              =link_to "#{@product.brand}", "" 
           %tr
             %th 商品のサイズ
-            %td 26.5cm
+            %td
+              =link_to "#{@product.size}", "" 
           %tr
             %th 商品の状態
-            %td 目立った傷や汚れなし
+            %td
+              =link_to "#{@product.product_state}", "" 
           %tr
             %th 配送料の負担
-            %td 送料込み(出品者負担)
+            %td
+              =link_to "#{@product.burden}", "" 
           %tr
             %th 配送の方法
             %td ゆうゆうメルカリ便
           %tr
             %th 配送元地域
-            %td=link_to "神奈川県", "#"
+            %td
+              =link_to "#{@product.prefecture.name}", ""
           %tr
             %th 発送日の目安
-            %td 1~2日で発送
+            %td
+              =link_to "#{@product.how_long}", "" 
 
     .item-price-box
-      %span.item-price-box__price ¥ 8,000
+      %span.item-price-box__price ¥ #{@product.price}
       %span.item-price-box__tax (税込)
       %span.item-price-box__shipping-fee 送料込み
       


### PR DESCRIPTION
# WHAT
商品詳細ページに商品情報のデータベースの値を反映する。

# WHY
商品詳細ページに出品した商品の情報を表示させるため。

# image
https://gyazo.com/285af4d755019404372740fe08302df0
